### PR TITLE
Feat/member

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/domain/Member.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Member.kt
@@ -1,32 +1,23 @@
 package com.capston.sumnote.domain
 
+import com.capston.sumnote.util.entity.BaseEntity
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import lombok.AccessLevel
-import lombok.AllArgsConstructor
-import lombok.Builder
-import lombok.Getter
-import lombok.NoArgsConstructor
 
 @Entity
 @Table(name = "MEMBERS")
-@Getter
-@Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
-class Member {
-
-    @Id @GeneratedValue
+class Member(
+    @Id
+    @GeneratedValue
     @Column(name = "member_id")
-    var id: Long? = null
+    var id: Long? = null,
 
     @Column(name = "member_email", nullable = false, unique = true)
-    var email: String? = null
+    var email: String? = null,
 
     @Column(name = "member_name")
     var name: String? = null
-
-}
+) : BaseEntity()

--- a/src/main/kotlin/com/capston/sumnote/domain/Member.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Member.kt
@@ -1,0 +1,32 @@
+package com.capston.sumnote.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import lombok.AccessLevel
+import lombok.AllArgsConstructor
+import lombok.Builder
+import lombok.Getter
+import lombok.NoArgsConstructor
+
+@Entity
+@Table(name = "MEMBERS")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+class Member {
+
+    @Id @GeneratedValue
+    @Column(name = "member_id")
+    var id: Long? = null
+
+    @Column(name = "member_email", nullable = false, unique = true)
+    var email: String? = null
+
+    @Column(name = "member_name")
+    var name: String? = null
+
+}

--- a/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
@@ -1,0 +1,22 @@
+package com.capston.sumnote.member.controller
+
+import com.capston.sumnote.member.dto.LoginDto
+import com.capston.sumnote.member.service.MemberServiceImpl
+import com.capston.sumnote.util.response.CustomApiResponse
+import org.springframework.web.bind.annotation.*
+import jakarta.validation.Valid
+
+@RestController
+@RequestMapping("/api/member")
+class MemberController(private val memberService: MemberServiceImpl) {
+
+    @PostMapping("/login")
+    fun login(@Valid @RequestBody dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
+        return memberService.login(dto)
+    }
+
+    @DeleteMapping("/withdraw/{email}")
+    fun withdraw(@PathVariable("email") email: String): CustomApiResponse<*> {
+        return memberService.withdraw(email)
+    }
+}

--- a/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
@@ -1,0 +1,28 @@
+package com.capston.sumnote.member.dto
+
+import com.capston.sumnote.domain.Member
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+class LoginDto {
+
+    data class Req(
+        @field:Email(message = "이메일 형식을 맞춰주세요.")
+        @field:NotBlank(message = "빈 값일 수 없습니다.")
+        val email: String,
+
+        @field:NotBlank(message = "빈 값일 수 없습니다.")
+        val name: String
+    ) {
+        fun toEntity(): Member {
+            return Member(
+                email = this.email,
+                name = this.name
+            )
+        }
+    }
+
+    data class Res(val email: String, val name: String) {
+        constructor(member: Member) : this(email = member.email.toString(), name = member.name.toString())
+    }
+}

--- a/src/main/kotlin/com/capston/sumnote/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/repository/MemberRepository.kt
@@ -1,0 +1,11 @@
+package com.capston.sumnote.member.repository
+
+import com.capston.sumnote.domain.Member
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.*
+
+@Repository
+interface MemberRepository : JpaRepository<Member, Long> {
+    fun findByEmail(email: String): Optional<Member>
+}

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
@@ -1,0 +1,9 @@
+package com.capston.sumnote.member.service
+
+import com.capston.sumnote.member.dto.LoginDto
+import com.capston.sumnote.util.response.CustomApiResponse
+
+interface MemberService {
+    fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
+    fun withdraw(email: String): CustomApiResponse<*>
+}

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -1,0 +1,69 @@
+package com.capston.sumnote.member.service
+
+import com.capston.sumnote.domain.Member
+import com.capston.sumnote.member.dto.LoginDto
+import com.capston.sumnote.member.repository.MemberRepository
+import com.capston.sumnote.util.exception.CustomValidationException
+import com.capston.sumnote.util.exception.EntityDuplicatedException
+import com.capston.sumnote.util.response.CustomApiResponse
+import com.capston.sumnote.util.valid.CustomValid
+import org.springframework.stereotype.Service
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+@Transactional(readOnly = true)
+class MemberServiceImpl(private val memberRepository: MemberRepository) : MemberService{
+
+    // 로그인
+    @Transactional
+    override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
+
+        // 이메일 형식 검증은 checkEmailRegexValid 을 사용하는 것이 아니라
+        // Controller 의 @Valid 사용
+
+        // 이메일 검증이 완료된 후의 로직
+        return memberRepository.findByEmail(dto.email).let {
+            if (!it.isPresent) { // 이메일이 존재하지 않으면 회원가입
+                checkEmailDuplicated(dto.email) // 이메일 중복 검증 -> 로직 상 불필요해 보임
+                val newMember: Member = dto.toEntity()
+                memberRepository.save(newMember)
+                CustomApiResponse.createSuccess(HttpStatus.CREATED.value(), LoginDto.Res(newMember), "회원가입 성공")
+            } else { // 이메일이 존재한다면 로그인
+                CustomApiResponse.createSuccess(HttpStatus.OK.value(), LoginDto.Res(it.get()), "로그인 성공")
+            }
+        }
+    }
+
+    // 회원탈퇴
+    @Transactional
+    override fun withdraw(email: String): CustomApiResponse<*> {
+
+        checkEmailRegexValid(email) // 이메일 형식
+
+        val foundMember: Optional<Member> = memberRepository.findByEmail(email)
+        return if (foundMember.isPresent) {
+            memberRepository.delete(foundMember.get())
+            CustomApiResponse.createSuccess(202, null, "회원탈퇴 성공")
+        } else {
+            CustomApiResponse.createFailWithoutData(404, "존재하지 않는 이메일입니다.")
+        }
+    }
+
+    private fun checkEmailRegexValid(email: String) {
+        // 이메일 형식 검증
+        if (!CustomValid.isEmailRegexValid(email)) {
+            throw CustomValidationException("이메일 형식을 맞춰주세요.")
+        }
+    }
+
+    private fun checkEmailDuplicated(email: String) {
+        // 이메일 중복 검증
+        val emailExists = memberRepository.findByEmail(email).isPresent
+        if (emailExists) {
+            throw EntityDuplicatedException("이미 사용중인 이메일입니다.")
+        }
+    }
+
+}

--- a/src/main/kotlin/com/capston/sumnote/util/controller/CustomErrorController.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/controller/CustomErrorController.kt
@@ -1,0 +1,41 @@
+package com.capston.sumnote.util.controller
+
+import jakarta.servlet.RequestDispatcher
+import jakarta.servlet.http.HttpServletRequest
+import com.capston.sumnote.util.response.CustomApiResponse
+import org.springframework.boot.web.servlet.error.ErrorController
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CustomErrorController : ErrorController {
+
+    @RequestMapping("/error")
+    fun handleError(request: HttpServletRequest): ResponseEntity<CustomApiResponse<Any?>> {
+        val status = request.getAttribute(RequestDispatcher.ERROR_STATUS_CODE) as? Int
+        status?.let {
+            return when (it) {
+                HttpStatus.NOT_FOUND.value() -> ResponseEntity
+                    .status(HttpStatus.NOT_FOUND)
+                    .body(CustomApiResponse(HttpStatus.NOT_FOUND.value(), null, "요청 경로를 찾을 수 없습니다."))
+                HttpStatus.BAD_REQUEST.value() -> ResponseEntity
+                    .status(HttpStatus.BAD_REQUEST)
+                    .body(CustomApiResponse(HttpStatus.BAD_REQUEST.value(), null, "잘못된 요청입니다."))
+                HttpStatus.FORBIDDEN.value() -> ResponseEntity
+                    .status(HttpStatus.FORBIDDEN)
+                    .body(CustomApiResponse(HttpStatus.FORBIDDEN.value(), null, "접근이 금지되었습니다."))
+                HttpStatus.METHOD_NOT_ALLOWED.value() -> ResponseEntity
+                    .status(HttpStatus.METHOD_NOT_ALLOWED)
+                    .body(CustomApiResponse(HttpStatus.METHOD_NOT_ALLOWED.value(), null, "허용되지 않는 메소드입니다."))
+                else -> ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(CustomApiResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, "내부 서버 오류가 발생했습니다."))
+            }
+        }
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(CustomApiResponse(HttpStatus.INTERNAL_SERVER_ERROR.value(), null, "내부 서버 오류가 발생했습니다."))
+    }
+}

--- a/src/main/kotlin/com/capston/sumnote/util/exception/CustomValidationException.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/CustomValidationException.kt
@@ -1,0 +1,4 @@
+package com.capston.sumnote.util.exception
+
+class CustomValidationException(message: String) :RuntimeException(message) {
+}

--- a/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
@@ -5,11 +5,10 @@ import com.capston.sumnote.util.response.CustomApiResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.MethodArgumentNotValidException
-import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.context.support.DefaultMessageSourceResolvable
+import org.springframework.web.bind.annotation.RestControllerAdvice
 
-@ControllerAdvice
+@RestControllerAdvice
 class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
@@ -48,6 +47,12 @@ class GlobalExceptionHandler {
         return ResponseEntity
             .status(HttpStatus.CONFLICT)
             .body(CustomApiResponse.createFailWithoutData(HttpStatus.CONFLICT.value(), message))
+    }
+
+    @ExceptionHandler(CustomValidationException::class)
+    fun handleCustomValidationException(e: CustomValidationException): ResponseEntity<CustomApiResponse<*>> {
+        val response = CustomApiResponse.createFailWithoutData(HttpStatus.BAD_REQUEST.value(), e.message ?: "유효하지 않은 요청입니다.")
+        return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
 }

--- a/src/main/kotlin/com/capston/sumnote/util/response/CustomApiResponse.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/response/CustomApiResponse.kt
@@ -1,6 +1,6 @@
 package com.capston.sumnote.util.response
 
-class CustomApiResponse<T> private constructor(
+class CustomApiResponse<T>(
     val status: Int,
     val data: T?,
     val message: String?

--- a/src/main/kotlin/com/capston/sumnote/util/valid/CustomValid.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/valid/CustomValid.kt
@@ -1,0 +1,13 @@
+package com.capston.sumnote.util.valid
+
+import java.util.regex.Pattern
+
+object CustomValid {
+
+    private const val emailRegex = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,6}$"
+
+    fun isEmailRegexValid(email: String): Boolean {
+        return Pattern.compile(emailRegex).matcher(email).matches()
+    }
+
+}


### PR DESCRIPTION
### 관련 이슈 

- close #3 

<br><br>

### 개발 내용

- 회원가입/로그인
- 회원탈퇴
- 전체적으로 프로젝트 세팅


<br><br>

### 기능 동작 스크린샷

`http://localhost:8080/api/member/login` 200 - 로그인 성공
<img width="1289" alt="스크린샷 2024-03-19 오후 4 24 15" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/5c7ed3a6-a7cc-4413-b6a9-da1603e021b6">

<br>

`http://localhost:8080/api/member/login` 201 - 회원가입 성공
<img width="1289" alt="스크린샷 2024-03-19 오후 4 15 24" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/1ec84a35-50ea-4d4f-8ac1-a9b8179e44a1">


<br>

`http://localhost:8080/api/member/login` 400  - email 형식이 맞지 않은 경우
<img width="1289" alt="스크린샷 2024-03-19 오후 4 26 28" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/510dd1b4-1b01-4a39-88bc-5030b822b73e">

<br>

`http://localhost:8080/api/member/withdraw/{email}` 202 - 회원 탈퇴 성공
<img width="1289" alt="스크린샷 2024-03-19 오후 4 26 40" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/612303cc-2160-4612-b199-261bf81225db">


<br>

`http://localhost:8080/api/member/withdraw/{email}` 400 - 이메일 형식 안맞음
<img width="1289" alt="스크린샷 2024-03-19 오후 4 26 48" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/fe2a17d2-1c1f-4710-8511-8b538de99d8f">


<br>

`http://localhost:8080/api/member/withdraw/{email}` 404 - 존재하지 않는 회원을 탈퇴시키려고 하는 경우
<img width="1289" alt="스크린샷 2024-03-19 오후 4 27 21" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/41a427cc-7272-4b04-a371-c9106c7b40f3">


<br><br>

### 개발 중 문제가 있었다면 어떻게 해결했는지 작성

- kotlin이 익숙하지 않아서 GPT의 도움을 많이 받음, 이 코드들을 기반으로 kotlin 기본 문법을 학습하고 익숙하게 할 예정이다.
