### PR TITLE
Feat/member

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/SumNoteApplication.kt
+++ b/src/main/kotlin/com/capston/sumnote/SumNoteApplication.kt
@@ -3,8 +3,10 @@ package com.capston.sumnote
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 class SumNoteApplication
 

--- a/src/main/kotlin/com/capston/sumnote/domain/Member.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Member.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import java.time.LocalDateTime
 
 @Entity
 @Table(name = "MEMBERS")
@@ -19,5 +20,11 @@ class Member(
     var email: String? = null,
 
     @Column(name = "member_name")
-    var name: String? = null
+    var name: String? = null,
+
+    @Column(name = "last_login_at")
+    var lastLoginAt: LocalDateTime? = null,
+
+    @Column(name = "is_active")
+    var isActive: Boolean = true
 ) : BaseEntity()

--- a/src/main/kotlin/com/capston/sumnote/domain/Member.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Member.kt
@@ -25,6 +25,6 @@ class Member(
     @Column(name = "last_login_at")
     var lastLoginAt: LocalDateTime? = null,
 
-    @Column(name = "is_active")
-    var isActive: Boolean = true
+    @Column(name = "is_auto_login_active")
+    var isAutoLoginActive: Boolean = true
 ) : BaseEntity()

--- a/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
@@ -15,6 +15,11 @@ class MemberController(private val memberService: MemberServiceImpl) {
         return memberService.login(dto)
     }
 
+    @PostMapping("/re-login")
+    fun reLogin(@Valid @RequestBody dto: LoginDto.Req) : CustomApiResponse<LoginDto.Res> {
+        return memberService.reLogin(dto)
+    }
+
     @DeleteMapping("/withdraw/{email}")
     fun withdraw(@PathVariable("email") email: String): CustomApiResponse<*> {
         return memberService.withdraw(email)

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
@@ -5,5 +5,6 @@ import com.capston.sumnote.util.response.CustomApiResponse
 
 interface MemberService {
     fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
+    fun reLogin(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
     fun withdraw(email: String): CustomApiResponse<*>
 }

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -21,30 +21,41 @@ class MemberServiceImpl(private val memberRepository: MemberRepository) : Member
     @Transactional
     override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
 
-        // 이메일 형식 검증은 checkEmailRegexValid 을 사용하는 것이 아니라
-        // Controller 의 @Valid 사용
+        // 이메일을 통해 사용자 정보를 조회
+        val optionalMember = memberRepository.findByEmail(dto.email)
 
-        // 이메일 검증이 완료된 후의 로직
-        return memberRepository.findByEmail(dto.email).let {
-            if (!it.isPresent) { // 이메일이 존재하지 않으면 회원가입
-                checkEmailDuplicated(dto.email) // 이메일 중복 검증 -> 로직 상 불필요해 보임
-                val newMember: Member = dto.toEntity().apply {
-                    // 회원가입 시점을 마지막 로그인 시간으로 설정
-                    this.lastLoginAt = LocalDateTime.now()
-                }
-                memberRepository.save(newMember)
-                CustomApiResponse.createSuccess(HttpStatus.CREATED.value(), LoginDto.Res(newMember), "회원가입 성공")
-            } else { // 이메일이 존재한다면 로그인
-                // 기존 회원이 로그인 시 마지막 로그인 시간 업데이트
-                it.get().apply {
-                    this.lastLoginAt = LocalDateTime.now()
-                } . let {
-                    updatedMember -> memberRepository.save(updatedMember)
-                }
-                CustomApiResponse.createSuccess(HttpStatus.OK.value(), LoginDto.Res(it.get()), "로그인 성공")
+        // 사용자 정보가 존재하면 활성 상태를 확인
+        if (optionalMember.isPresent) {
+            val member = optionalMember.get()
+
+            // 계정이 비활성화된 경우 예외 발생
+            if (!member.isAutoLoginActive) {
+                throw CustomValidationException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
             }
+
+            // 사용자의 마지막 로그인 시간 업데이트
+            member.apply {
+                this.lastLoginAt = LocalDateTime.now()
+            }.also {
+                memberRepository.save(it)
+            }
+
+            // 로그인 성공 응답을 반환
+            return CustomApiResponse.createSuccess(HttpStatus.OK.value(), LoginDto.Res(member), "로그인 성공")
+        } else {
+            // 사용자 정보가 없으면 회원가입
+            checkEmailDuplicated(dto.email) // 이메일 중복 검증
+            val newMember: Member = dto.toEntity().apply {
+                // 회원가입 시점을 마지막 로그인 시간으로 설정
+                this.lastLoginAt = LocalDateTime.now()
+                this.isAutoLoginActive = true // 새 계정을 활성 상태로 설정
+            }
+            memberRepository.save(newMember)
+            // 회원가입 성공 응답을 반환
+            return CustomApiResponse.createSuccess(HttpStatus.CREATED.value(), LoginDto.Res(newMember), "회원가입 성공")
         }
     }
+
 
     // 회원탈퇴
     @Transactional

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -1,6 +1,5 @@
 package com.capston.sumnote.member.service
 
-import com.capston.sumnote.domain.Member
 import com.capston.sumnote.member.dto.LoginDto
 import com.capston.sumnote.member.repository.MemberRepository
 import com.capston.sumnote.util.exception.CustomValidationException
@@ -12,80 +11,76 @@ import org.springframework.stereotype.Service
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
-import java.util.*
 
 @Service
 @Transactional(readOnly = true)
-class MemberServiceImpl(private val memberRepository: MemberRepository) : MemberService{
+class MemberServiceImpl(private val memberRepository: MemberRepository) : MemberService {
 
     // 로그인
     @Transactional
-    override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
+    override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> =
+        processLogin(dto, allowReactivation = false)
 
-        // 이메일을 통해 사용자 정보를 조회
-        val optionalMember = memberRepository.findByEmail(dto.email)
+    // 재로그인
+    @Transactional
+    override fun reLogin(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> =
+        processLogin(dto, allowReactivation = true)
 
-        // 사용자 정보가 존재하면 활성 상태를 확인
-        if (optionalMember.isPresent) {
-            val member = optionalMember.get()
+    // 로그인과 재로그인 공통 로직
+    private fun processLogin(dto: LoginDto.Req, allowReactivation: Boolean): CustomApiResponse<LoginDto.Res> {
+        val member = memberRepository.findByEmail(dto.email).orElseGet {
 
-            // 계정이 비활성화된 경우 예외 발생
-            if (!member.isAutoLoginActive) {
-                throw AutoLoginDeactivateException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
-            }
-
-            // 사용자의 마지막 로그인 시간 업데이트
-            member.apply {
-                this.lastLoginAt = LocalDateTime.now()
-            }.also {
-                memberRepository.save(it)
-            }
-
-            // 로그인 성공 응답을 반환
-            return CustomApiResponse.createSuccess(HttpStatus.OK.value(), LoginDto.Res(member), "로그인 성공")
-        } else {
-            // 사용자 정보가 없으면 회원가입
-            checkEmailDuplicated(dto.email) // 이메일 중복 검증
-            val newMember: Member = dto.toEntity().apply {
-                // 회원가입 시점을 마지막 로그인 시간으로 설정
-                this.lastLoginAt = LocalDateTime.now()
-                this.isAutoLoginActive = true // 새 계정을 활성 상태로 설정
+            // 사용자 정보가 없으면 회원가입 진행
+            val newMember = dto.toEntity().apply {
+                lastLoginAt = LocalDateTime.now()
+                isAutoLoginActive = true
             }
             memberRepository.save(newMember)
-            // 회원가입 성공 응답을 반환
-            return CustomApiResponse.createSuccess(HttpStatus.CREATED.value(), LoginDto.Res(newMember), "회원가입 성공")
+            newMember
         }
+
+        // login 으로 요청이 온 경우
+        if (!allowReactivation && !member.isAutoLoginActive) {
+            throw AutoLoginDeactivateException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
+        }
+
+        // re-login 으로 요청이 온 경우
+        member.apply {
+            lastLoginAt = LocalDateTime.now()
+            if (!isAutoLoginActive) {
+                isAutoLoginActive = true // 비활성화된 계정 재활성화
+            }
+        }.also {
+            memberRepository.save(it)
+        }
+
+        return CustomApiResponse.createSuccess(HttpStatus.OK.value(), LoginDto.Res(member), if (allowReactivation) "재로그인 성공" else "로그인 성공")
     }
 
-
-    // 회원탈퇴
     @Transactional
     override fun withdraw(email: String): CustomApiResponse<*> {
+        checkEmailRegexValid(email)
 
-        checkEmailRegexValid(email) // 이메일 형식
-
-        val foundMember: Optional<Member> = memberRepository.findByEmail(email)
-        return if (foundMember.isPresent) {
-            memberRepository.delete(foundMember.get())
+        memberRepository.findByEmail(email).ifPresentOrElse({ member ->
+            memberRepository.delete(member)
             CustomApiResponse.createSuccess(202, null, "회원탈퇴 성공")
-        } else {
-            CustomApiResponse.createFailWithoutData(404, "존재하지 않는 이메일입니다.")
-        }
+        }, {
+            throw CustomValidationException("존재하지 않는 이메일입니다.")
+        })
+
+        return CustomApiResponse.createFailWithoutData(404, "존재하지 않는 이메일입니다.")
     }
 
     private fun checkEmailRegexValid(email: String) {
-        // 이메일 형식 검증
         if (!CustomValid.isEmailRegexValid(email)) {
             throw CustomValidationException("이메일 형식을 맞춰주세요.")
         }
     }
 
     private fun checkEmailDuplicated(email: String) {
-        // 이메일 중복 검증
-        val emailExists = memberRepository.findByEmail(email).isPresent
-        if (emailExists) {
+        memberRepository.findByEmail(email).ifPresent {
             throw EntityDuplicatedException("이미 사용중인 이메일입니다.")
         }
     }
-
 }
+

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -5,6 +5,7 @@ import com.capston.sumnote.member.dto.LoginDto
 import com.capston.sumnote.member.repository.MemberRepository
 import com.capston.sumnote.util.exception.CustomValidationException
 import com.capston.sumnote.util.exception.EntityDuplicatedException
+import com.capston.sumnote.util.exception.AutoLoginDeactivateException
 import com.capston.sumnote.util.response.CustomApiResponse
 import com.capston.sumnote.util.valid.CustomValid
 import org.springframework.stereotype.Service
@@ -30,7 +31,7 @@ class MemberServiceImpl(private val memberRepository: MemberRepository) : Member
 
             // 계정이 비활성화된 경우 예외 발생
             if (!member.isAutoLoginActive) {
-                throw CustomValidationException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
+                throw AutoLoginDeactivateException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
             }
 
             // 사용자의 마지막 로그인 시간 업데이트

--- a/src/main/kotlin/com/capston/sumnote/util/exception/AutoLoginDeactivateException.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/AutoLoginDeactivateException.kt
@@ -1,0 +1,4 @@
+package com.capston.sumnote.util.exception
+
+class AutoLoginDeactivateException(message: String): RuntimeException(message) {
+}

--- a/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
@@ -57,7 +57,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(MemberDeactivateException::class)
     fun handleMemberDeactivateException(e: MemberDeactivateException): ResponseEntity<CustomApiResponse<*>> {
-        val response = CustomApiResponse.createFailWithoutData(HttpStatus.UNAUTHORIZED.value(), e.message ?: "자동 로그아웃 됩니다.")
+        val response = CustomApiResponse.createFailWithoutData(HttpStatus.UNAUTHORIZED.value(), e.message ?: "자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
         return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
     }
 

--- a/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
@@ -57,8 +57,8 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(AutoLoginDeactivateException::class)
     fun handleMemberDeactivateException(e: AutoLoginDeactivateException): ResponseEntity<CustomApiResponse<*>> {
-        val response = CustomApiResponse.createFailWithoutData(HttpStatus.UNAUTHORIZED.value(), e.message ?: "자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
-        return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
+        val response = CustomApiResponse.createFailWithoutData(HttpStatus.REQUEST_TIMEOUT.value(), e.message ?: "자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
+        return ResponseEntity(response, HttpStatus.REQUEST_TIMEOUT)
     }
 
 }

--- a/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
@@ -55,4 +55,10 @@ class GlobalExceptionHandler {
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
+    @ExceptionHandler(MemberDeactivateException::class)
+    fun handleMemberDeactivateException(e: MemberDeactivateException): ResponseEntity<CustomApiResponse<*>> {
+        val response = CustomApiResponse.createFailWithoutData(HttpStatus.UNAUTHORIZED.value(), e.message ?: "자동 로그아웃 됩니다.")
+        return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
+    }
+
 }

--- a/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/GlobalExceptionHandler.kt
@@ -55,8 +55,8 @@ class GlobalExceptionHandler {
         return ResponseEntity(response, HttpStatus.BAD_REQUEST)
     }
 
-    @ExceptionHandler(MemberDeactivateException::class)
-    fun handleMemberDeactivateException(e: MemberDeactivateException): ResponseEntity<CustomApiResponse<*>> {
+    @ExceptionHandler(AutoLoginDeactivateException::class)
+    fun handleMemberDeactivateException(e: AutoLoginDeactivateException): ResponseEntity<CustomApiResponse<*>> {
         val response = CustomApiResponse.createFailWithoutData(HttpStatus.UNAUTHORIZED.value(), e.message ?: "자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
         return ResponseEntity(response, HttpStatus.UNAUTHORIZED)
     }

--- a/src/main/kotlin/com/capston/sumnote/util/exception/MemberDeactivateException.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/MemberDeactivateException.kt
@@ -1,0 +1,4 @@
+package com.capston.sumnote.util.exception
+
+class MemberDeactivateException(message: String): RuntimeException(message) {
+}

--- a/src/main/kotlin/com/capston/sumnote/util/exception/MemberDeactivateException.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/exception/MemberDeactivateException.kt
@@ -1,4 +1,0 @@
-package com.capston.sumnote.util.exception
-
-class MemberDeactivateException(message: String): RuntimeException(message) {
-}

--- a/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
@@ -14,7 +14,7 @@ class ScheduledTasks(private val memberRepository: MemberRepository) {
         memberRepository.findAll().forEach { member ->
             if (member.lastLoginAt?.isBefore(twoWeeksAgo) == true) {
                 // 사용자 비활성화, 즉 자동 로그아웃
-                member.isActive = false
+                member.isAutoLoginActive = false
                 memberRepository.save(member)
             }
         }

--- a/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
@@ -1,0 +1,23 @@
+package com.capston.sumnote.util.service
+
+import com.capston.sumnote.member.repository.MemberRepository
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ScheduledTasks(private val memberRepository: MemberRepository) {
+
+    @Scheduled(fixedRate = 86400000) // 매일 실행
+    fun deactivateInactiveUsers() {
+        val twoWeeksAgo = LocalDateTime.now().minusWeeks(2)
+        memberRepository.findAll().forEach { member ->
+            if (member.lastLoginAt?.isBefore(twoWeeksAgo) == true) {
+                // 사용자 비활성화, 즉 자동 로그아웃
+                member.isActive = false
+                memberRepository.save(member)
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
### 관련 이슈 

- close #6 

<br><br>

### 개발 내용

- 로그인 자동 만료
- 로그인과 재로그인 controller 분리
- 서비스 계층에서 로그인과 재로그인 공통로직 작성
- 호출 메소드에 따라 `allowReactivation` 다르게 전달
- 201 회원가입은 삭제, 로그인으로 통일


<br><br>

### 기능 동작 스크린샷

회원가입 + 로그인 : `http://localhost:8080/api/member/login` 200 OK
<img width="737" alt="스크린샷 2024-03-20 오후 5 36 14" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/b8ff1c8c-080a-4edb-9362-c8b6e407231d">

<br><br>

`is_auto_login_active` 필드를 false로 바꾸고 (즉, 자동 로그인 기한이 만료되었다고 가정하는 상황)
<img width="1392" alt="스크린샷 2024-03-20 오후 5 36 32" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/b90aac91-b920-43cf-a8c0-1e74b5c98fdb">

<br><br>

재로그인을 하면 200 OK가 뜸
재로그인 : `http://localhost:8080/api/member/re-login` 200 OK

<img width="737" alt="스크린샷 2024-03-20 오후 5 36 48" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/d1fca751-d8db-413a-8645-7fe8d3f31b0e">

<br><br>

DB도 새로고침 하면 `is_auto_login_active` 필드가 true로 바뀐 것을 볼 수 있음
<img width="1392" alt="스크린샷 2024-03-20 오후 5 36 57" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/6cad8974-33c8-44d0-b037-fb83a8e790bf">


<br><br>

### 개발 중 문제가 있었다면 어떻게 해결했는지 작성

-
