### PR TITLE
Feat/member

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,12 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+	// JWT
+	implementation("io.jsonwebtoken:jjwt-api:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
+
 	compileOnly("org.projectlombok:lombok")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	annotationProcessor("org.projectlombok:lombok")

--- a/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
@@ -22,7 +22,7 @@ class LoginDto {
         }
     }
 
-    data class Res(val email: String, val name: String) {
-        constructor(member: Member) : this(email = member.email.toString(), name = member.name.toString())
+    data class Res(val email: String, val name: String, val token: String) {
+        constructor(member: Member, token: String) : this(email = member.email.toString(), name = member.name.toString(), token = token)
     }
 }

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -5,6 +5,7 @@ import com.capston.sumnote.member.repository.MemberRepository
 import com.capston.sumnote.util.exception.CustomValidationException
 import com.capston.sumnote.util.exception.EntityDuplicatedException
 import com.capston.sumnote.util.exception.AutoLoginDeactivateException
+import com.capston.sumnote.util.jwt.JwtTokenProvider
 import com.capston.sumnote.util.response.CustomApiResponse
 import com.capston.sumnote.util.valid.CustomValid
 import org.springframework.stereotype.Service
@@ -14,7 +15,10 @@ import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
-class MemberServiceImpl(private val memberRepository: MemberRepository) : MemberService {
+class MemberServiceImpl(
+    private val memberRepository: MemberRepository,
+    private val jwtTokenProvider: JwtTokenProvider
+) : MemberService {
 
     // 로그인
     @Transactional

--- a/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
@@ -17,6 +17,7 @@ class JwtTokenProvider : Serializable {
     private lateinit var secretKey: String
 
     private lateinit var key: Key
+//    private val validityInMilliseconds: Long = 1000 * 60 // TEST: 60초
     private val validityInMilliseconds: Long = 1000 * 60 * 60 * 24 * 14 // 토큰 유효기간 2주
 
     @PostConstruct

--- a/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
@@ -1,0 +1,35 @@
+package com.capston.sumnote.util.jwt
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import java.security.Key
+import java.util.*
+import javax.crypto.spec.SecretKeySpec
+
+class JwtTokenProvider(secretKey: String) {
+
+    private val key: Key
+    private val validityInMilliseconds: Long = 1000 * 60 * 60 * 24 * 14 // 토큰 유효기간 2주
+
+    init {
+        val decodedKey = Base64.getDecoder().decode(secretKey) // 생성자에서 제공된 secretKey 를 Base64로 디코딩
+        this.key = SecretKeySpec(decodedKey, 0, decodedKey.size, "HmacSHA256") // 디코딩 된 키로 SecretKeySpec 객체 생성
+    }
+
+    fun createToken(email: String, roles: List<String>) : String {
+        val claims = Jwts.claims().setSubject(email) // 사용자의 이메일을 주제로 JWT 클레임 세트 생성
+        claims["roles"] = roles // 사용자 역할 정보를 클레임에 추가
+
+        // 토큰 발행 시간과 만료 시간을 설정
+        val now = Date()
+        val validity = Date(now.time + validityInMilliseconds)
+
+        // JWT 토큰 생성 및 반환
+        return Jwts.builder()
+            .setClaims(claims) // 클레임
+            .setIssuedAt(now) // 발행 시간
+            .setExpiration(validity) // 만료 시간
+            .signWith(key, SignatureAlgorithm.HS256) // HS256 알고리즘 이용
+            .compact() // 토큰 생성
+    }
+}

--- a/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/jwt/JwtTokenProvider.kt
@@ -2,18 +2,27 @@ package com.capston.sumnote.util.jwt
 
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.SignatureAlgorithm
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.io.Serializable
 import java.security.Key
 import java.util.*
 import javax.crypto.spec.SecretKeySpec
 
-class JwtTokenProvider(secretKey: String) {
+@Component
+class JwtTokenProvider : Serializable {
 
-    private val key: Key
+    @Value("\${jwt.secret-key}")
+    private lateinit var secretKey: String
+
+    private lateinit var key: Key
     private val validityInMilliseconds: Long = 1000 * 60 * 60 * 24 * 14 // 토큰 유효기간 2주
 
-    init {
-        val decodedKey = Base64.getDecoder().decode(secretKey) // 생성자에서 제공된 secretKey 를 Base64로 디코딩
-        this.key = SecretKeySpec(decodedKey, 0, decodedKey.size, "HmacSHA256") // 디코딩 된 키로 SecretKeySpec 객체 생성
+    @PostConstruct
+    fun init() {
+        val decodedKey = Base64.getDecoder().decode(secretKey)
+        this.key = SecretKeySpec(decodedKey, 0, decodedKey.size, "HmacSHA256")
     }
 
     fun createToken(email: String, roles: List<String>) : String {

--- a/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
@@ -9,8 +9,10 @@ import java.time.LocalDateTime
 class ScheduledTasks(private val memberRepository: MemberRepository) {
 
     @Scheduled(fixedRate = 86400000) // 매일 실행
+//    @Scheduled(fixedRate = 60000) // TEST : 60초
     fun deactivateInactiveUsers() {
         val twoWeeksAgo = LocalDateTime.now().minusWeeks(2)
+//        val twoWeeksAgo = LocalDateTime.now().minusMinutes(1) // TEST : 60초
         memberRepository.findAll().forEach { member ->
             if (member.lastLoginAt?.isBefore(twoWeeksAgo) == true) {
                 // 사용자 비활성화, 즉 자동 로그아웃


### PR DESCRIPTION
### 관련 이슈 

- close #8 

<br><br>

### 개발 내용

- 토큰 생성
- 토큰 자동 만료
- `application.properties`에  `jwt.secret-key` 추가


<br><br>

### 기능 동작 스크린샷

토큰이 만료된 경우 : `http://localhost:8080/api/member/login` 408(Request Timeout)

<img width="745" alt="스크린샷 2024-03-21 오후 3 54 20" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/e1af8bd6-a6dd-4349-8afd-8737c691da7c">

<br><br>

재로그인 요청 : `http://localhost:8080/api/member/re-login` 200(OK), 토큰값 정상 생성 확인
<img width="745" alt="스크린샷 2024-03-21 오후 3 54 40" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/d569ee76-e1fe-4b5a-bcb7-37a754d20a36">



<br><br>

### +) 토큰 만료 확인

- `util/jwt/JwtTokenProvider` 에서 `validityInMilliseconds` 값을 `1000 * 60`(1분) 으로 변경 >> 토큰의 유효 시간을 1분으로 변경
- `util/service/ScheduledTasks` 에서 `@Scheduled(fixedRate = 60000) (1분) 으로 변경 >> 1분 마다 확인한다
- `util/service/ScheduledTasks` 에서 `twoWeeksAgo` 값을 `LocalDateTime.now().minusMinutes(1)` (1분) 로 변경 >> 이 변수로 1분마다 상태 확인/변경
