### PR TITLE
Fix/re login

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/SumNoteApplication.kt
+++ b/src/main/kotlin/com/capston/sumnote/SumNoteApplication.kt
@@ -3,10 +3,8 @@ package com.capston.sumnote
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
-import org.springframework.scheduling.annotation.EnableScheduling
 
 @EnableJpaAuditing
-@EnableScheduling
 @SpringBootApplication
 class SumNoteApplication
 

--- a/src/main/kotlin/com/capston/sumnote/domain/Member.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Member.kt
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "MEMBERS")
@@ -20,11 +19,5 @@ class Member(
     var email: String? = null,
 
     @Column(name = "member_name")
-    var name: String? = null,
-
-    @Column(name = "last_login_at")
-    var lastLoginAt: LocalDateTime? = null,
-
-    @Column(name = "is_auto_login_active")
-    var isAutoLoginActive: Boolean = true
+    var name: String? = null
 ) : BaseEntity()

--- a/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
@@ -15,11 +15,6 @@ class MemberController(private val memberService: MemberServiceImpl) {
         return memberService.login(dto)
     }
 
-    @PostMapping("/re-login")
-    fun reLogin(@Valid @RequestBody dto: LoginDto.Req) : CustomApiResponse<LoginDto.Res> {
-        return memberService.reLogin(dto)
-    }
-
     @DeleteMapping("/withdraw/{email}")
     fun withdraw(@PathVariable("email") email: String): CustomApiResponse<*> {
         return memberService.withdraw(email)

--- a/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/controller/MemberController.kt
@@ -3,16 +3,20 @@ package com.capston.sumnote.member.controller
 import com.capston.sumnote.member.dto.LoginDto
 import com.capston.sumnote.member.service.MemberServiceImpl
 import com.capston.sumnote.util.response.CustomApiResponse
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.web.bind.annotation.*
 import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
 
 @RestController
 @RequestMapping("/api/member")
 class MemberController(private val memberService: MemberServiceImpl) {
 
     @PostMapping("/login")
-    fun login(@Valid @RequestBody dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
-        return memberService.login(dto)
+    fun login(@Valid @RequestBody dto: LoginDto.Req, response: HttpServletResponse): CustomApiResponse<LoginDto.Res> {
+        val (responseData, token) = memberService.login(dto)
+        response.addHeader("Authorization", "Bearer $token")
+        return CustomApiResponse.createSuccess(HttpStatus.OK.value(), responseData, "로그인 성공")
     }
 
     @DeleteMapping("/withdraw/{email}")

--- a/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/dto/LoginDto.kt
@@ -22,7 +22,5 @@ class LoginDto {
         }
     }
 
-    data class Res(val email: String, val name: String, val token: String) {
-        constructor(member: Member, token: String) : this(email = member.email.toString(), name = member.name.toString(), token = token)
-    }
+    data class Res(val email: String, val name: String)
 }

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
@@ -4,6 +4,6 @@ import com.capston.sumnote.member.dto.LoginDto
 import com.capston.sumnote.util.response.CustomApiResponse
 
 interface MemberService {
-    fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
+    fun login(dto: LoginDto.Req): Pair<LoginDto.Res, String>
     fun withdraw(email: String): CustomApiResponse<*>
 }

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberService.kt
@@ -5,6 +5,5 @@ import com.capston.sumnote.util.response.CustomApiResponse
 
 interface MemberService {
     fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
-    fun reLogin(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res>
     fun withdraw(email: String): CustomApiResponse<*>
 }

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -19,7 +19,7 @@ class MemberServiceImpl(
 
         // 로그인
         @Transactional
-        override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
+        override fun login(dto: LoginDto.Req): Pair<LoginDto.Res, String> {
             val member = memberRepository.findByEmail(dto.email).orElseGet {
                 memberRepository.save(dto.toEntity()) // 사용자 정보가 없으면 회원가입 진행
             }
@@ -27,9 +27,9 @@ class MemberServiceImpl(
             // JWT 토큰 생성
             val token = jwtTokenProvider.createToken(member.email.toString(), listOf("ROLE_USER"))
 
-            // 로그인 응답에 토큰 포함하여 반환
-            val response = LoginDto.Res(member.email.toString(), member.name.toString(), token)
-            return CustomApiResponse.createSuccess(HttpStatus.OK.value(), response, "로그인 성공")
+            // 로그인 응답 준비 (토큰 제외)
+            val response = LoginDto.Res(member.email.toString(), member.name.toString())
+            return Pair(response, token)
         }
 
     @Transactional
@@ -40,7 +40,7 @@ class MemberServiceImpl(
             .orElseThrow { CustomValidationException("존재하지 않는 이메일입니다.") }
 
         memberRepository.delete(member)
-        return CustomApiResponse.createSuccess(202, null, "회원탈퇴 성공")
+        return CustomApiResponse.createSuccess(200, null, "회원탈퇴 성공")
     }
 
     private fun checkEmailRegexValid(email: String) {

--- a/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/member/service/MemberServiceImpl.kt
@@ -3,15 +3,12 @@ package com.capston.sumnote.member.service
 import com.capston.sumnote.member.dto.LoginDto
 import com.capston.sumnote.member.repository.MemberRepository
 import com.capston.sumnote.util.exception.CustomValidationException
-import com.capston.sumnote.util.exception.EntityDuplicatedException
-import com.capston.sumnote.util.exception.AutoLoginDeactivateException
 import com.capston.sumnote.util.security.jwt.JwtTokenProvider
 import com.capston.sumnote.util.response.CustomApiResponse
 import com.capston.sumnote.util.valid.CustomValid
 import org.springframework.stereotype.Service
 import org.springframework.http.HttpStatus
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 @Service
 @Transactional(readOnly = true)
@@ -20,64 +17,30 @@ class MemberServiceImpl(
     private val jwtTokenProvider: JwtTokenProvider
 ) : MemberService {
 
-    // 로그인
-    @Transactional
-    override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> =
-        processLogin(dto, allowReactivation = false)
-
-    // 재로그인
-    @Transactional
-    override fun reLogin(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> =
-        processLogin(dto, allowReactivation = true)
-
-    // 로그인과 재로그인 공통 로직
-    private fun processLogin(dto: LoginDto.Req, allowReactivation: Boolean): CustomApiResponse<LoginDto.Res> {
-        val member = memberRepository.findByEmail(dto.email).orElseGet {
-
-            // 사용자 정보가 없으면 회원가입 진행
-            val newMember = dto.toEntity().apply {
-                lastLoginAt = LocalDateTime.now()
-                isAutoLoginActive = true
+        // 로그인
+        @Transactional
+        override fun login(dto: LoginDto.Req): CustomApiResponse<LoginDto.Res> {
+            val member = memberRepository.findByEmail(dto.email).orElseGet {
+                memberRepository.save(dto.toEntity()) // 사용자 정보가 없으면 회원가입 진행
             }
-            memberRepository.save(newMember)
-            return@orElseGet newMember
+
+            // JWT 토큰 생성
+            val token = jwtTokenProvider.createToken(member.email.toString(), listOf("ROLE_USER"))
+
+            // 로그인 응답에 토큰 포함하여 반환
+            val response = LoginDto.Res(member.email.toString(), member.name.toString(), token)
+            return CustomApiResponse.createSuccess(HttpStatus.OK.value(), response, "로그인 성공")
         }
-
-        // login 으로 요청이 온 경우
-        if (!allowReactivation && !member.isAutoLoginActive) {
-            throw AutoLoginDeactivateException("자동 로그아웃 되었습니다. 다시 로그인 해주세요.")
-        }
-
-        // re-login 으로 요청이 온 경우, 자동 로그인 비활성화 상태인 계정을 재활성화
-        if (!member.isAutoLoginActive) {
-            member.apply {
-                lastLoginAt = LocalDateTime.now()
-                isAutoLoginActive = true
-            }
-            memberRepository.save(member)
-        }
-
-        // JWT 토큰 생성
-        val token = jwtTokenProvider.createToken(member.email.toString(), listOf("ROLE_USER")) // 역할은 예시입니다.
-
-        // 로그인 응답에 토큰 포함하여 반환
-        val response = LoginDto.Res(member.email.toString(), member.name.toString(), token) // 수정된 생성자를 사용
-        return CustomApiResponse.createSuccess(HttpStatus.OK.value(), response, if (allowReactivation) "재로그인 성공" else "로그인 성공")
-
-    }
 
     @Transactional
     override fun withdraw(email: String): CustomApiResponse<*> {
         checkEmailRegexValid(email)
 
-        memberRepository.findByEmail(email).ifPresentOrElse({ member ->
-            memberRepository.delete(member)
-            CustomApiResponse.createSuccess(202, null, "회원탈퇴 성공")
-        }, {
-            throw CustomValidationException("존재하지 않는 이메일입니다.")
-        })
+        val member = memberRepository.findByEmail(email)
+            .orElseThrow { CustomValidationException("존재하지 않는 이메일입니다.") }
 
-        return CustomApiResponse.createFailWithoutData(404, "존재하지 않는 이메일입니다.")
+        memberRepository.delete(member)
+        return CustomApiResponse.createSuccess(202, null, "회원탈퇴 성공")
     }
 
     private fun checkEmailRegexValid(email: String) {
@@ -86,10 +49,5 @@ class MemberServiceImpl(
         }
     }
 
-    private fun checkEmailDuplicated(email: String) {
-        memberRepository.findByEmail(email).ifPresent {
-            throw EntityDuplicatedException("이미 사용중인 이메일입니다.")
-        }
-    }
 }
 

--- a/src/main/kotlin/com/capston/sumnote/util/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/security/SecurityConfig.kt
@@ -29,7 +29,6 @@ class SecurityConfig(
             }
             authorizeHttpRequests {
                 authorize("/api/member/login", permitAll) // 로그인 경로는 누구나 접근 가능
-                authorize("/api/member/re-login", permitAll) // 재로그인 경로도 누구나 접근 가능
                 authorize(anyRequest, authenticated) // 그 외 모든 요청은 인증 필요
             }
             httpBasic {} // HTTP 기본 인증 활성화 (필요한 경우)

--- a/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/service/ScheduledTasks.kt
@@ -1,25 +1,25 @@
-package com.capston.sumnote.util.service
-
-import com.capston.sumnote.member.repository.MemberRepository
-import org.springframework.scheduling.annotation.Scheduled
-import org.springframework.stereotype.Service
-import java.time.LocalDateTime
-
-@Service
-class ScheduledTasks(private val memberRepository: MemberRepository) {
-
-    @Scheduled(fixedRate = 86400000) // 매일 실행
-//    @Scheduled(fixedRate = 60000) // TEST : 60초
-    fun deactivateInactiveUsers() {
-        val twoWeeksAgo = LocalDateTime.now().minusWeeks(2)
-//        val twoWeeksAgo = LocalDateTime.now().minusMinutes(1) // TEST : 60초
-        memberRepository.findAll().forEach { member ->
-            if (member.lastLoginAt?.isBefore(twoWeeksAgo) == true) {
-                // 사용자 비활성화, 즉 자동 로그아웃
-                member.isAutoLoginActive = false
-                memberRepository.save(member)
-            }
-        }
-
-    }
-}
+//package com.capston.sumnote.util.service
+//
+//import com.capston.sumnote.member.repository.MemberRepository
+//import org.springframework.scheduling.annotation.Scheduled
+//import org.springframework.stereotype.Service
+//import java.time.LocalDateTime
+//
+//@Service
+//class ScheduledTasks(private val memberRepository: MemberRepository) {
+//
+//    @Scheduled(fixedRate = 86400000) // 매일 실행
+////    @Scheduled(fixedRate = 60000) // TEST : 60초
+//    fun deactivateInactiveUsers() {
+//        val twoWeeksAgo = LocalDateTime.now().minusWeeks(2)
+////        val twoWeeksAgo = LocalDateTime.now().minusMinutes(1) // TEST : 60초
+//        memberRepository.findAll().forEach { member ->
+//            if (member.lastLoginAt?.isBefore(twoWeeksAgo) == true) {
+//                // 사용자 비활성화, 즉 자동 로그아웃
+//                member.isAutoLoginActive = false
+//                memberRepository.save(member)
+//            }
+//        }
+//
+//    }
+//}


### PR DESCRIPTION
### 관련 이슈 

- close #16 

<br><br>

### 개발 내용

- 로직이 이상해서 `re-login` API는 삭제
- `login` 으로 요청 오면 토큰값 생성
- 생성된 토큰값은 응답 body가 아니라 header에 전달

<br><br>

### 기능 동작 스크린샷

`http://localhost:8080/api/member/login` 200(OK)

- 응답이 잘 오는 것을 확인
- header에 token값 존재 확인
<img width="1315" alt="스크린샷 2024-04-08 오후 9 17 26" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/f83c9289-dea0-48a9-92d1-630e2babf040">
<img width="1315" alt="스크린샷 2024-04-08 오후 9 17 48" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/4cc0ef5e-9fe7-435e-a8ff-fa9c66a1c698">

<br><br>

- token 값이 일치하지 않으면 401
<img width="1315" alt="스크린샷 2024-04-08 오후 9 18 08" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/45cd97f3-9081-4e4a-8301-c2f9f10094e2">

<br><br>

- token 값이 일치하면 정상 처리
<img width="1315" alt="스크린샷 2024-04-08 오후 9 18 14" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/33f20248-be1b-4cdc-9f72-2dcaa432820c">


<br><br>

### 개발 중 문제가 있었다면 어떻게 해결했는지 작성

-
