### PR TITLE
Feat/get note

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/note/controller/SumNoteController.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/controller/SumNoteController.kt
@@ -54,20 +54,20 @@ class SumNoteController(private val noteService: NoteService) {
         }
     }
 
-//    @GetMapping
-//    fun getNote(@RequestParam noteId: Long): ResponseEntity<CustomApiResponse<*>> {
-//
-//        // 헤더에 포함된 토큰으로 이메일 값 가져오기
-//        val authentication = SecurityContextHolder.getContext().authentication
-//        val principal = authentication.principal
-//        val email = if (principal is User) {
-//            principal.username
-//        } else {
-//            principal.toString()
-//        }
-//
-//        // 응답
-//        val response = noteService.getNote(noteId)
-//        return ResponseEntity.status(HttpStatus.OK).body(CustomApiResponse.createSuccess(200, response, "노트 조회에 성공했습니다."))
-//    }
+    @GetMapping ("note")
+    fun getNote(@RequestParam noteId: Long): ResponseEntity<CustomApiResponse<*>> {
+
+        // 헤더에 포함된 토큰으로 이메일 값 가져오기
+        val authentication = SecurityContextHolder.getContext().authentication
+        val principal = authentication.principal
+        val email = if (principal is User) {
+            principal.username
+        } else {
+            principal.toString()
+        }
+
+        // 응답
+        val response = noteService.getNote(noteId)
+        return ResponseEntity.status(HttpStatus.OK).body(response)
+    }
 }

--- a/src/main/kotlin/com/capston/sumnote/note/controller/SumNoteController.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/controller/SumNoteController.kt
@@ -53,4 +53,21 @@ class SumNoteController(private val noteService: NoteService) {
             else -> ResponseEntity.badRequest().body(CustomApiResponse.createFailWithoutData(400, "Invalid type parameter"))
         }
     }
+
+//    @GetMapping
+//    fun getNote(@RequestParam noteId: Long): ResponseEntity<CustomApiResponse<*>> {
+//
+//        // 헤더에 포함된 토큰으로 이메일 값 가져오기
+//        val authentication = SecurityContextHolder.getContext().authentication
+//        val principal = authentication.principal
+//        val email = if (principal is User) {
+//            principal.username
+//        } else {
+//            principal.toString()
+//        }
+//
+//        // 응답
+//        val response = noteService.getNote(noteId)
+//        return ResponseEntity.status(HttpStatus.OK).body(CustomApiResponse.createSuccess(200, response, "노트 조회에 성공했습니다."))
+//    }
 }

--- a/src/main/kotlin/com/capston/sumnote/note/dto/GetNoteDto.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/dto/GetNoteDto.kt
@@ -1,0 +1,18 @@
+package com.capston.sumnote.note.dto
+
+data class GetNoteDto(
+    val note: NoteDetail,
+    val notePages: List<NotePageDetail>
+)
+
+data class NoteDetail(
+    val noteId: Long,
+    val title: String
+)
+
+data class NotePageDetail(
+    val notePageId: Long,
+    val title: String,
+    val content: String,
+    val isQuizExist: Boolean
+)

--- a/src/main/kotlin/com/capston/sumnote/note/dto/GetNotesDto.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/dto/GetNotesDto.kt
@@ -1,10 +1,14 @@
 package com.capston.sumnote.note.dto
 
 import java.time.LocalDateTime
+import com.capston.sumnote.util.response.DateFormatter
 
 class GetNotesDto(
-    val id:Long,
+    val noteId: Long,
     val title: String,
-    val createdAt: LocalDateTime,
-    val lastModifiedAt: LocalDateTime
-)
+    createdAt: LocalDateTime,
+    lastModifiedAt: LocalDateTime
+) {
+    val createdAt: String = DateFormatter.formatDateTime(createdAt)
+    val lastModifiedAt: String = DateFormatter.formatDateTime(lastModifiedAt)
+}

--- a/src/main/kotlin/com/capston/sumnote/note/repository/NoteRepository.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/repository/NoteRepository.kt
@@ -4,10 +4,14 @@ import com.capston.sumnote.domain.Note
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import com.capston.sumnote.note.dto.GetNotesDto
-
+import org.springframework.data.jpa.repository.Query
 
 @Repository
 interface NoteRepository : JpaRepository<Note, Long> {
+    @Query("SELECT new com.capston.sumnote.note.dto.GetNotesDto(n.id, n.title, n.createdAt, n.lastModifiedAt) FROM Note n WHERE n.member.email = :email ORDER BY n.lastModifiedAt DESC")
     fun findTop5ByMemberEmailOrderByLastModifiedAtDesc(email: String): List<GetNotesDto>
+
+    @Query("SELECT new com.capston.sumnote.note.dto.GetNotesDto(n.id, n.title, n.createdAt, n.lastModifiedAt) FROM Note n WHERE n.member.email = :email ORDER BY n.lastModifiedAt DESC")
     fun findAllByMemberEmailOrderByLastModifiedAtDesc(email: String): List<GetNotesDto>
+
 }

--- a/src/main/kotlin/com/capston/sumnote/note/service/NoteService.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/service/NoteService.kt
@@ -7,4 +7,5 @@ interface NoteService {
     fun createNote(dto: CreateNoteDto, email: String): CustomApiResponse<*>
     fun findRecentNotesLimited(email: String): CustomApiResponse<*>
     fun findAllNotesSorted(email: String): CustomApiResponse<*>
+    fun getNote(noteId: Long): CustomApiResponse<*>
 }

--- a/src/main/kotlin/com/capston/sumnote/note/service/NoteServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/service/NoteServiceImpl.kt
@@ -3,8 +3,7 @@ package com.capston.sumnote.note.service
 import com.capston.sumnote.domain.Note
 import com.capston.sumnote.domain.NotePage
 import com.capston.sumnote.member.repository.MemberRepository
-import com.capston.sumnote.note.dto.CreateNoteDto
-import com.capston.sumnote.note.dto.GetNotesDto
+import com.capston.sumnote.note.dto.*
 import com.capston.sumnote.note.repository.NoteRepository
 import com.capston.sumnote.note.repository.NotePageRepository
 import com.capston.sumnote.util.response.CustomApiResponse
@@ -53,6 +52,29 @@ class NoteServiceImpl(
     override fun findAllNotesSorted(email: String): CustomApiResponse<List<GetNotesDto>> {
         val notes = noteRepository.findAllByMemberEmailOrderByLastModifiedAtDesc(email)
         return CustomApiResponse.createSuccess(HttpStatus.OK.value(), notes, "모든 노트 조회에 성공하였습니다.")
+    }
+
+    override fun getNote(noteId: Long): CustomApiResponse<*> {
+
+        // 노트 찾기 + 예외 처리
+        val note = noteRepository.findById(noteId).orElse(null)
+            ?: return CustomApiResponse.createFailWithoutData(HttpStatus.NOT_FOUND.value(), "id가 " + noteId + "인 노트는 존재하지 않습니다.")
+
+        // 응답 데이터 만들기
+        val noteDetail = NoteDetail(noteId = note.id!!, title = note.title!!)
+        val notePagesDetails = note.notePages.map {
+            NotePageDetail(
+                notePageId = it.id!!,
+                title = it.title!!,
+                content = it.content!!,
+                isQuizExist = it.isQuizExists ?: false
+            )
+        }
+
+        val getNoteDto = GetNoteDto(note = noteDetail, notePages = notePagesDetails)
+
+        // 응답
+        return CustomApiResponse.createSuccess(HttpStatus.OK.value(), getNoteDto, "노트 조회에 성공하였습니다.")
     }
 
 

--- a/src/main/kotlin/com/capston/sumnote/util/response/DateFormatter.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/response/DateFormatter.kt
@@ -1,0 +1,12 @@
+package com.capston.sumnote.util.response
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object DateFormatter {
+    private val formatter = DateTimeFormatter.ofPattern("yyyy.M.d. a h:mm")
+
+    fun formatDateTime(dateTime: LocalDateTime): String {
+        return dateTime.format(formatter)
+    }
+}


### PR DESCRIPTION
### 관련 이슈 

- refs #21 

<br><br>

### 개발 내용

- 노트 조회 API 응답 형식 일부 변경
- 노트 단건 조회 API 작성


<br><br>

### 기능 동작 스크린샷

노트 단건 조회 API : 200 (OK)
<img width="1270" alt="스크린샷 2024-04-24 오후 5 03 48" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/3301b8c2-4a87-4437-8197-442fbdfcd75c">


<br>


노트 단건 조회 API : 404 (Not Found)
<img width="1270" alt="스크린샷 2024-04-24 오후 5 03 40" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/544f1597-18ae-4268-bab5-18002891c631">


<br><br>

### 고려사항
- API path.. -> `api/sum-note/note/noteId=1` 이 형식이 맞는걸까..
