### PR TITLE
:ambulance: 로그인 시 토큰값 필요한 오류 해결

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/util/security/jwt/JwtTokenFilter.kt
+++ b/src/main/kotlin/com/capston/sumnote/util/security/jwt/JwtTokenFilter.kt
@@ -19,11 +19,14 @@ class JwtTokenFilter(private val jwtTokenProvider: JwtTokenProvider) : GenericFi
         val request = req as HttpServletRequest
         val response = res as HttpServletResponse
         val token = jwtTokenProvider.resolveToken(request)
+        val requestURI = request.requestURI
 
         try {
             if (token != null && jwtTokenProvider.validateToken(token)) {
                 val auth = jwtTokenProvider.getAuthentication(token)
                 SecurityContextHolder.getContext().authentication = auth
+            } else if (requestURI == "/api/member/login") {
+                // 그대로 요청 진행
             } else {
                 unauthorizedResponse(response)
                 return


### PR DESCRIPTION
### 관련 이슈 

- refs #3 

<br><br>

### 개발 내용

- 로그인 경로는 토큰값이 없어도 요청이 가능해야 함
- Filter에서 URI로 구분하여 해당 로직 반영


<br><br>

### 기능 동작 스크린샷

200(OK)
<img width="1077" alt="스크린샷 2024-04-25 오후 10 52 20" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/9745bc86-5f35-4d9e-bfb6-5b16079cff13">


<br><br>

### 개발 중 문제가 있었다면 어떻게 해결했는지 작성

-
