### PR TITLE
:sparkles: 노트 삭제 API 작성

### DIFF
--- a/src/main/kotlin/com/capston/sumnote/domain/Note.kt
+++ b/src/main/kotlin/com/capston/sumnote/domain/Note.kt
@@ -19,7 +19,7 @@ class Note(
     @JoinColumn(name = "member_id")
     var member: Member? = null,
 
-    @OneToMany(mappedBy = "note", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "note", cascade = [CascadeType.ALL], fetch = FetchType.LAZY, orphanRemoval = true)
     var notePages: MutableList<NotePage> = mutableListOf(),
 
     @OneToOne(cascade = [CascadeType.ALL], fetch = FetchType.LAZY)

--- a/src/main/kotlin/com/capston/sumnote/note/controller/NoteController.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/controller/NoteController.kt
@@ -47,4 +47,10 @@ class NoteController(private val noteService: NoteService) {
         val responseData = noteService.addNotePage(getCurrentUserEmail(), noteId, dto)
         return ResponseEntity.status(responseData.status).body(responseData)
     }
+
+    @DeleteMapping("{noteId}")
+    fun deleteNoteAndQuiz(@PathVariable("noteId") noteId: Long): ResponseEntity<CustomApiResponse<*>> {
+        val responseData = noteService.deleteNoteAndQuiz(getCurrentUserEmail(), noteId)
+        return ResponseEntity.status(responseData.status).body(responseData)
+    }
 }

--- a/src/main/kotlin/com/capston/sumnote/note/service/NoteService.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/service/NoteService.kt
@@ -11,4 +11,5 @@ interface NoteService {
     fun getNote(email: String, noteId: Long): CustomApiResponse<*>
     fun changeTitle(email: String, noteId: Long, dto: ChangeTitleDto): CustomApiResponse<*>
     fun addNotePage(email: String, noteId: Long, dto: AddNotePageDto): CustomApiResponse<*>
+    fun deleteNoteAndQuiz(email: String, noteId: Long): CustomApiResponse<*>
 }

--- a/src/main/kotlin/com/capston/sumnote/note/service/NoteServiceImpl.kt
+++ b/src/main/kotlin/com/capston/sumnote/note/service/NoteServiceImpl.kt
@@ -115,6 +115,30 @@ class NoteServiceImpl(
     }
 
     /**
+     * 노트 삭제
+     */
+    @Transactional
+    override fun deleteNoteAndQuiz(email:String, noteId: Long): CustomApiResponse<*> {
+
+        // 노트 검증 (1. 노트가 존재하는지, 2. 노트가 사용자의 것인지)
+        val (note, errorResponse) = verifyNoteOwnership(email, noteId)
+        if (errorResponse != null) {
+            return errorResponse
+        }
+
+        // 4-1. 노트 + 노트 페이지 삭제
+        note?.let { noteRepository.delete(it) }
+
+        // TODO: 4-2. 퀴즈 + 퀴즈 페이지 -> 퀴즈 생성 오류 해결 후 개발
+
+        // ResponseBody 에 포함될 데이터
+        return CustomApiResponse.createSuccessWithoutData<Unit>(
+            HttpStatus.OK.value(), "노트가 정상적으로 삭제되었습니다."
+        )
+
+    }
+
+    /**
      * 공통 로직
      */
     private fun verifyNoteOwnership(email: String, noteId: Long): Pair<Note?, CustomApiResponse<*>?> {


### PR DESCRIPTION
### 관련 이슈 

- close #21 

<br><br>

### 개발 내용

- 노트 삭제 API 작성


<br><br>

### 기능 동작 스크린샷

`http://localhost:8080/api/sum-note/2` 200(OK)
<img width="1281" alt="스크린샷 2024-05-07 오전 11 08 14" src="https://github.com/SumNote/sumnote-kopring-server/assets/98332877/0efef3d4-ff9b-43ae-9917-b47ad77c59e6">


<br><br>

### 개발 중 문제가 있었다면 어떻게 해결했는지 작성

- `CascadeType.ALL` + `orphanRemoval = true` 여야 부모 엔티티가 자식 엔티티의 생명주기를 관리하는 줄 알았는데, `CascadeType.ALL` 만 해도 적용이 된다..? (더 찾아보기)
